### PR TITLE
Rename token list to reference Element

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ const addressesJson = require(`src/addresses/${network}.addresses.json`);
 
 getTokenList(
   addressesJson,
-  `${network} token list`,
+  "Element",
   `dist/${network}.tokenlist.json`
 )
   .then(() => process.exit(0))


### PR DESCRIPTION
Trying to integrate this tokenlist into the Balancer UI results in it being displayed with the name "mainnet token list" which isn't very descriptive.

I think it makes sense to just rename the list to refer to the project and let the filename/chainIds refer to the network.