### PR TITLE
Make the npm scripts less confusing by adding underscore prefixes to internal scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
   },
   "scripts": {
     "update-elf-contracts-typechain": "npm install git+https://github.com/element-fi/elf-contracts-typechain.git",
-    "fetch-addresses-json-goerli": "curl https://raw.githubusercontent.com/element-fi/elf-deploy/main/addresses/frontend-goerli.addresses.json > src/addresses/goerli.addresses.json",
-    "fetch-addresses-json-mainnet": "curl https://raw.githubusercontent.com/element-fi/elf-deploy/main/addresses/frontend-mainnet.addresses.json > src/addresses/mainnet.addresses.json",
-    "build-tokenlist-goerli": "npm run fetch-addresses-json-goerli && bash scripts/build-tokenlist.sh goerli",
-    "build-tokenlist-mainnet": "npm run fetch-addresses-json-mainnet && bash scripts/build-tokenlist.sh mainnet",
-    "build-index": "bash scripts/build-index.sh",
-    "build": " npm run build-tokenlist-goerli && npm run build-tokenlist-mainnet && npm run build-index && npm run copy-files",
-    "copy-files": "bash scripts/copy-dist-files.sh"
+    "_fetch-addresses-json-goerli": "curl https://raw.githubusercontent.com/element-fi/elf-deploy/main/addresses/frontend-goerli.addresses.json > src/addresses/goerli.addresses.json",
+    "_fetch-addresses-json-mainnet": "curl https://raw.githubusercontent.com/element-fi/elf-deploy/main/addresses/frontend-mainnet.addresses.json > src/addresses/mainnet.addresses.json",
+    "_build-tokenlist-goerli": "npm run _fetch-addresses-json-goerli && bash scripts/build-tokenlist.sh goerli",
+    "_build-tokenlist-mainnet": "npm run _fetch-addresses-json-mainnet && bash scripts/build-tokenlist.sh mainnet",
+    "_build-index": "bash scripts/build-index.sh",
+    "build": " npm run _build-tokenlist-goerli && npm run _build-tokenlist-mainnet && npm run _build-index && npm run _copy-files",
+    "_copy-files": "bash scripts/copy-dist-files.sh"
   }
 }


### PR DESCRIPTION
When you want to add a new asset to the tokenlists, it can be confusing to navigate all the npm script we've got in package.json.

This PR adds an underscore prefix to better hint that `npm run build` is really all you need to run if you're not trying to do anything fancy.