### PR TITLE
Update Curvelptoken info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,9 +65,9 @@
       }
     },
     "@elementfi/core-typechain": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@elementfi/core-typechain/-/core-typechain-1.0.1.tgz",
-      "integrity": "sha512-6HXZH+XeMWP4bpd2yXAyPdqQj2WgrQ3PGrKZpd8WEKJMynMBRqMIGJyyTbBrCdQEYDCXdJMdPzQUxQKLueVaXw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@elementfi/core-typechain/-/core-typechain-1.0.2.tgz",
+      "integrity": "sha512-KW3WLUzXBEOk/HPnkJN2b6dfWTKSX6bnZxaXn2UtlzcbiMN5ItM0xRozAKd9ucQXFiGi7P+L2FsgXRt7uT+wnA==",
       "dev": true,
       "requires": {
         "tsc": "^2.0.4"
@@ -2261,14 +2261,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "elf-contracts-typechain": {
-      "version": "git+https://github.com/element-fi/elf-contracts-typechain.git#895088f815a02a5c1c9f2d1777ae5b80178b80c7",
-      "from": "git+https://github.com/element-fi/elf-contracts-typechain.git",
-      "dev": true,
-      "requires": {
-        "tsc": "^2.0.4"
       }
     },
     "elliptic": {

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "tsc": "^2.0.3"
   },
   "main": "dist/index.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "types": "dist/index.d.ts",
   "devDependencies": {
-    "@elementfi/core-typechain": "^1.0.1",
+    "@elementfi/core-typechain": "^1.0.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-vyper": "^2.0.1",
     "@openzeppelin/contracts": "^3.4.0",

--- a/src/curveToken.ts
+++ b/src/curveToken.ts
@@ -155,26 +155,35 @@ export async function getCurveTokenInfo({
       (_, idx) => curvePool.coins(idx) as Promise<string>
     )
   );
-  const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
-  const wethIdx = poolAssets.findIndex((address) => address === WETH);
 
+  // The below logic is intended to replace the use of WETH, the wrapped ether
+  // token for the native ETH token. We do this because both of the crvTriCrypto
+  // pools that element supports has a wrapper "deposit" contract provided by curve
+  // to make it more accessible to users. Otherwise, any time a user wants to use
+  // the crvTriCrypto pool with their ETH, the user would have to wrap it first.
+  // The deposit wrapper does this automatically. Element inherits this same
+  // paradigm and so we identify first the crvTriCrypto pools and replace the
+  // pool with the deposit wrapper and the WETH poolAsset with the ETH_CONSTANT
+  const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+  const wethIdx = poolAssets.findIndex(
+    (poolAssetAddress) => poolAssetAddress === WETH
+  );
   if (wethIdx !== -1) {
     const CRV_TRI_CRYPTO = "0xcA3d75aC011BF5aD07a98d02f18225F9bD9A6BDF";
     const CRV_TRI_CRYPTO_POOL = "0x80466c64868E1ab14a1Ddf27A676C3fcBE638Fe5";
     const CRV_TRI_CRYPTO_DEPOSIT = "0x331aF2E331bd619DefAa5DAc6c038f53FCF9F785";
     if (address === CRV_TRI_CRYPTO && pool === CRV_TRI_CRYPTO_POOL) {
       pool = CRV_TRI_CRYPTO_DEPOSIT;
+      poolAssets[wethIdx] = ETH_CONSTANT;
     }
 
     const CRV_3_CRYPTO = "0xc4AD29ba4B3c580e6D59105FFf484999997675Ff";
     const CRV_3_CRYPTO_POOL = "0xD51a44d3FaE010294C616388b506AcdA1bfAAE46";
     const CRV_3_CRYPTO_DEPOSIT = "0x3993d34e7e99Abf6B6f367309975d1360222D446";
-
     if (address === CRV_3_CRYPTO && pool === CRV_3_CRYPTO_POOL) {
       pool = CRV_3_CRYPTO_DEPOSIT;
+      poolAssets[wethIdx] = ETH_CONSTANT;
     }
-
-    poolAssets[wethIdx] = ETH_CONSTANT;
   }
 
   return {

--- a/src/curveToken.ts
+++ b/src/curveToken.ts
@@ -160,7 +160,7 @@ export async function getCurveTokenInfo({
     (k) => k.startsWith("add_liquidity")
   ) as string;
 
-  // example: "remove_liquidity_one_coin(uint256[2],uint256)"
+  // example: "remove_liquidity_one_coin(uint256[2],int128,uint256)"
   const removeLiquidityFuncSig = Object.keys(curvePoolContract.functions).find(
     (k) => k.startsWith("remove_liquidity_one_coin")
   ) as string;
@@ -192,6 +192,14 @@ export async function getCurveTokenInfo({
     )
   );
 
+  const removeLiqFnIsUint256 =
+    removeLiquidityFuncSig
+      .substring(
+        addLiquidityFuncSig.indexOf("(") + 1,
+        addLiquidityFuncSig.indexOf(")")
+      )
+      .split(",")[1] === "uint256";
+
   return {
     chainId,
     address,
@@ -202,8 +210,7 @@ export async function getCurveTokenInfo({
     extensions: {
       pool,
       poolAssets,
-      addLiquidityFuncSig,
-      removeLiquidityFuncSig,
+      removeLiqFnIsUint256,
     },
   };
 }

--- a/src/curveToken.ts
+++ b/src/curveToken.ts
@@ -192,14 +192,6 @@ export async function getCurveTokenInfo({
     )
   );
 
-  const removeLiqFnIsUint256 =
-    removeLiquidityFuncSig
-      .substring(
-        addLiquidityFuncSig.indexOf("(") + 1,
-        addLiquidityFuncSig.indexOf(")")
-      )
-      .split(",")[1] === "uint256";
-
   return {
     chainId,
     address,
@@ -210,7 +202,9 @@ export async function getCurveTokenInfo({
     extensions: {
       pool,
       poolAssets,
-      removeLiqFnIsUint256,
+      curveRemoveLiqFnIsUint256:
+        removeLiquidityFuncSig ===
+        "remove_liquidity_one_coin(uint256,uint256,uint256)",
     },
   };
 }

--- a/src/external.ts
+++ b/src/external.ts
@@ -16,6 +16,7 @@ async function getExternalTokenInfo(
   chainId: number,
   address: string
 ): Promise<ExternalTokenInfo> {
+  await provider.ready;
   if (address === ETH_CONSTANT) {
     return {
       chainId,

--- a/src/external.ts
+++ b/src/external.ts
@@ -8,7 +8,7 @@ import { CurveLpTokenInfo } from "./types";
 
 export const provider = hre.ethers.provider;
 
-const ETH_CONSTANT = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+export const ETH_CONSTANT = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 
 type ExternalTokenInfo = TokenInfo | CurveLpTokenInfo;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export const mainnetTokenList: TokenList = {
       "description": "The yield position, ie: Yearn yvcrvLUSD"
     }
   },
-  "timestamp": "2022-03-03T17:45:59.096Z",
+  "timestamp": "2022-03-03T19:46:36.501Z",
   "version": {
     "major": 0,
     "minor": 0,
@@ -98,7 +98,7 @@ export const mainnetTokenList: TokenList = {
         "curve"
       ],
       "extensions": {
-        "pool": "0xbebc44782c7db0a1a60cb6fe97d0b483032ff1c7",
+        "pool": "0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7",
         "poolAssets": [
           "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
@@ -126,13 +126,6 @@ export const mainnetTokenList: TokenList = {
       "address": "0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3",
       "symbol": "MIM",
       "name": "Magic Internet Money",
-      "decimals": 18
-    },
-    {
-      "chainId": 1,
-      "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-      "symbol": "WETH",
-      "name": "Wrapped Ether",
       "decimals": 18
     },
     {
@@ -227,11 +220,11 @@ export const mainnetTokenList: TokenList = {
         "curve"
       ],
       "extensions": {
-        "pool": "0xD51a44d3FaE010294C616388b506AcdA1bfAAE46",
+        "pool": "0x3993d34e7e99Abf6B6f367309975d1360222D446",
         "poolAssets": [
           "0xdAC17F958D2ee523a2206206994597C13D831ec7",
           "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
-          "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+          "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
         ],
         "curveRemoveLiqFnIsUint256": true
       }
@@ -246,11 +239,11 @@ export const mainnetTokenList: TokenList = {
         "curve"
       ],
       "extensions": {
-        "pool": "0x80466c64868E1ab14a1Ddf27A676C3fcBE638Fe5",
+        "pool": "0x331aF2E331bd619DefAa5DAc6c038f53FCF9F785",
         "poolAssets": [
           "0xdAC17F958D2ee523a2206206994597C13D831ec7",
           "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
-          "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+          "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
         ],
         "curveRemoveLiqFnIsUint256": true
       }
@@ -2166,7 +2159,7 @@ export const goerliTokenList: TokenList = {
       "description": "The yield position, ie: Yearn yvcrvLUSD"
     }
   },
-  "timestamp": "2022-03-03T17:45:06.205Z",
+  "timestamp": "2022-03-03T19:45:46.235Z",
   "version": {
     "major": 0,
     "minor": 0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export const mainnetTokenList: TokenList = {
       "description": "The yield position, ie: Yearn yvcrvLUSD"
     }
   },
-  "timestamp": "2022-01-18T16:38:03.191Z",
+  "timestamp": "2022-03-03T17:45:59.096Z",
   "version": {
     "major": 0,
     "minor": 0,
@@ -104,8 +104,7 @@ export const mainnetTokenList: TokenList = {
           "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "0xdAC17F958D2ee523a2206206994597C13D831ec7"
         ],
-        "addLiquidityFuncSig": "add_liquidity(uint256[3],uint256)",
-        "removeLiquidityFuncSig": "remove_liquidity_one_coin(uint256,int128,uint256)"
+        "curveRemoveLiqFnIsUint256": false
       }
     },
     {
@@ -179,8 +178,7 @@ export const mainnetTokenList: TokenList = {
           "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
           "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"
         ],
-        "addLiquidityFuncSig": "add_liquidity(uint256[2],uint256)",
-        "removeLiquidityFuncSig": "remove_liquidity_one_coin(uint256,int128,uint256)"
+        "curveRemoveLiqFnIsUint256": false
       }
     },
     {
@@ -198,8 +196,7 @@ export const mainnetTokenList: TokenList = {
           "0xBC6DA0FE9aD5f3b0d58160288917AA56653660E9",
           "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"
         ],
-        "addLiquidityFuncSig": "add_liquidity(uint256[2],uint256)",
-        "removeLiquidityFuncSig": "remove_liquidity_one_coin(uint256,int128,uint256)"
+        "curveRemoveLiqFnIsUint256": false
       }
     },
     {
@@ -217,8 +214,7 @@ export const mainnetTokenList: TokenList = {
           "0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3",
           "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"
         ],
-        "addLiquidityFuncSig": "add_liquidity(uint256[2],uint256)",
-        "removeLiquidityFuncSig": "remove_liquidity_one_coin(uint256,int128,uint256)"
+        "curveRemoveLiqFnIsUint256": false
       }
     },
     {
@@ -237,8 +233,7 @@ export const mainnetTokenList: TokenList = {
           "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
           "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
         ],
-        "addLiquidityFuncSig": "add_liquidity(uint256[3],uint256)",
-        "removeLiquidityFuncSig": "remove_liquidity_one_coin(uint256,uint256,uint256)"
+        "curveRemoveLiqFnIsUint256": true
       }
     },
     {
@@ -257,8 +252,7 @@ export const mainnetTokenList: TokenList = {
           "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
           "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
         ],
-        "addLiquidityFuncSig": "add_liquidity(uint256[3],uint256)",
-        "removeLiquidityFuncSig": "remove_liquidity_one_coin(uint256,uint256,uint256)"
+        "curveRemoveLiqFnIsUint256": true
       }
     },
     {
@@ -276,8 +270,7 @@ export const mainnetTokenList: TokenList = {
           "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
           "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
         ],
-        "addLiquidityFuncSig": "add_liquidity(uint256[2],uint256)",
-        "removeLiquidityFuncSig": "remove_liquidity_one_coin(uint256,int128,uint256)"
+        "curveRemoveLiqFnIsUint256": false
       }
     },
     {
@@ -295,8 +288,7 @@ export const mainnetTokenList: TokenList = {
           "0xdB25f211AB05b1c97D595516F45794528a807ad8",
           "0xD71eCFF9342A5Ced620049e616c5035F1dB98620"
         ],
-        "addLiquidityFuncSig": "add_liquidity(uint256[2],uint256)",
-        "removeLiquidityFuncSig": "remove_liquidity_one_coin(uint256,int128,uint256)"
+        "curveRemoveLiqFnIsUint256": false
       }
     },
     {
@@ -2174,7 +2166,7 @@ export const goerliTokenList: TokenList = {
       "description": "The yield position, ie: Yearn yvcrvLUSD"
     }
   },
-  "timestamp": "2022-01-18T16:36:38.502Z",
+  "timestamp": "2022-03-03T17:45:06.205Z",
   "version": {
     "major": 0,
     "minor": 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export interface CurveLpTokenInfo extends TokenInfo {
 
     /**
      * The removeLiquidity function in curve pool contracts has a selector
-     * parameter which arbitrarily is either uint256 or uint128. To select
+     * parameter which arbitrarily is either uint256 or int128. To select
      * between the two options, we must pass the correct case as input
      * */
     removeLiqFnIsUint256: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface CurveLpTokenInfo extends TokenInfo {
      * parameter which arbitrarily is either uint256 or int128. To select
      * between the two options, we must pass the correct case as input
      * */
-    removeLiqFnIsUint256: boolean;
+    curveRemoveLiqFnIsUint256: boolean;
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,8 +9,10 @@ export { TokenInfo, TokenList } from "@uniswap/token-lists/src";
 
 export interface CurveLpTokenInfo extends TokenInfo {
   extensions: {
-    /** The address of the pool the curve LP token corresponds to, may sometimes
-     * be the address of the token itself  */
+    /**
+     * The address of the pool the curve LP token corresponds to, may sometimes
+     * be the address of the token itself
+     * */
     pool: string;
 
     /**
@@ -19,13 +21,12 @@ export interface CurveLpTokenInfo extends TokenInfo {
      */
     poolAssets: string[];
 
-    /** Function signature corresponding to the add liquidity function
-     * on the pool contract*/
-    addLiquidityFuncSig: string;
-
-    /** Function signature corresponding to the remove liquidity function
-     * on the pool contract*/
-    removeLiquidityFuncSig: string;
+    /**
+     * The removeLiquidity function in curve pool contracts has a selector
+     * parameter which arbitrarily is either uint256 or uint128. To select
+     * between the two options, we must pass the correct case as input
+     * */
+    removeLiqFnIsUint256: boolean;
   };
 }
 


### PR DESCRIPTION
- Mostly adding a hardcoded solution for the deposit zappers for both crvTriCrypto tokens (these allow us use ETH instead of WETH). Unfortunately there is no way to dynamically find these from on chain or other reference material
- Some struct changes which corresponds to changes in the zapper contract post audit
- Simple mod for using the curve registry contract to lookup most of the curve pools